### PR TITLE
Feature/revamp filtering

### DIFF
--- a/Backend/Library/Library.Api/Controllers/Base/BaseCrudController.cs
+++ b/Backend/Library/Library.Api/Controllers/Base/BaseCrudController.cs
@@ -71,6 +71,13 @@ namespace Library.Api.Controllers.Base
                     Code = "BadFilterFormat"
                 };
             }
+            catch (ArgumentException ex)
+            {
+                throw new customWebExceptions.ValidationException(ex.Message)
+                {
+                    Code = "BadFilterArgument"
+                };
+            }
 
 
             if (entities == null)

--- a/Backend/Library/Library.Api/Controllers/Base/BaseCrudController.cs
+++ b/Backend/Library/Library.Api/Controllers/Base/BaseCrudController.cs
@@ -68,14 +68,14 @@ namespace Library.Api.Controllers.Base
             {
                 throw new customWebExceptions.ValidationException(ex.Message)
                 {
-                    Code = "BadFilterFormat"
+                    Code = "BadFilterQueryFormat"
                 };
             }
             catch (ArgumentException ex)
             {
                 throw new customWebExceptions.ValidationException(ex.Message)
                 {
-                    Code = "BadFilterArgument"
+                    Code = "BadFilterOnArgument"
                 };
             }
 

--- a/Backend/Library/Library.Dal/Helpers/LinqHelpers.cs
+++ b/Backend/Library/Library.Dal/Helpers/LinqHelpers.cs
@@ -30,7 +30,7 @@ namespace Library.Dal.Helpers
             }
             else
             {
-                throw new FormatException("Filtering on this property is not supported");
+                throw new ArgumentException("Filtering on this property is not supported");
             }
 
         }
@@ -70,10 +70,17 @@ namespace Library.Dal.Helpers
                 // Check if the string contains a single date and the a correct operator
                 if (singleOperandOperators.Contains(filterQuery[0].ToString()))
                 {
+                    string symbol = "";
                     // Get the symbol from the string
-                    var symbol = filterQuery[0].ToString();
+                    foreach (string op in singleOperandOperators)
+                    {
+                        if (filterQuery.Contains(op))
+                        {
+                            symbol = op;
+                        }
+                    }
                     // Get the date from the string
-                    var dateString = filterQuery.Substring(1);
+                    var dateString = filterQuery.Substring(symbol.Length);
 
                     DateTime date = DateTime.Parse(dateString);
 
@@ -186,10 +193,18 @@ namespace Library.Dal.Helpers
                 // Check if the string contains a single int and the a correct operator
                 if (singleOperandOperators.Contains(filterQuery[0].ToString()))
                 {
+                    string symbol = "";
                     // Get the symbol from the string
-                    var symbol = filterQuery[0].ToString();
+                    foreach (string op in singleOperandOperators)
+                    {
+                        if (filterQuery.Contains(op))
+                        {
+                            symbol = op;
+                        }
+                    }
+
                     // Get the int from the string
-                    var intString = filterQuery.Substring(1);
+                    var intString = filterQuery.Substring(symbol.Length);
 
                     var int1 = int.Parse(intString);
 
@@ -365,7 +380,7 @@ namespace Library.Dal.Helpers
                 // Check if the string contains two ints
                 else if (filterQuery.Contains("~") && int.TryParse(filterQuery.Split("~")[0], out int queryInt1) && int.TryParse(filterQuery.Split("~")[1], out int queryInt2))
                 {
-                    
+
                     if (isCollection)
                     {
                         // x.SomeCollection.Any(y => y.Id >= 2 AndAlso y.Id <= 5)
@@ -383,12 +398,12 @@ namespace Library.Dal.Helpers
                 {
                     throw new FormatException("Please make sure to use the correct format for date. Please follow the following instructions for guidance: \n " +
                          "If you want to fetch records with:\n" +
-                         "1. exact date, use the following format: =100\n" +
-                         "2. date greater than or equal to, use the following format: >=100\n" +
-                         "3. date less than or equal to, use the following format: <=100\n" +
-                         "4. date greater than, use the following format: >100\n" +
-                         "5. date less than, use the following format: <100\n" +
-                         "6. dates between two dates, use the following format: 100~200\n");
+                         "1. exact number, use the following format: =100\n" +
+                         "2. numbers greater than or equal to, use the following format: >=100\n" +
+                         "3. numbers less than or equal to, use the following format: <=100\n" +
+                         "4. numbers greater than, use the following format: >100\n" +
+                         "5. numbers less than, use the following format: <100\n" +
+                         "6. numbers between two numbers, use the following format: 100~200\n");
                 }
 
             }

--- a/Backend/Library/Library.Dal/Library.Dal.csproj
+++ b/Backend/Library/Library.Dal/Library.Dal.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Backend/Library/Library.Dal/Repos/Base/BaseViewRepo.cs
+++ b/Backend/Library/Library.Dal/Repos/Base/BaseViewRepo.cs
@@ -54,6 +54,10 @@ namespace Library.Dal.Repos.Base
                     // Apply the predicate to filter the query
                     table = table.Where(predicate);
                 }
+                else
+                {
+                    throw new ArgumentException("Invalid filterOn property name");
+                }
             }
 
 

--- a/Backend/Library/Library.Dal/Repos/Base/BaseViewRepo.cs
+++ b/Backend/Library/Library.Dal/Repos/Base/BaseViewRepo.cs
@@ -1,7 +1,4 @@
-﻿
-
-
-
+﻿using System.Linq.Dynamic.Core;
 
 namespace Library.Dal.Repos.Base
 {
@@ -44,6 +41,7 @@ namespace Library.Dal.Repos.Base
             // Filtering
             if (!String.IsNullOrWhiteSpace(filterOn) && !String.IsNullOrWhiteSpace(filterQuery))
             {
+
                 // Get the PropertyInfo object for the property to filter on using reflection
                 var propertyInfo = typeof(T).GetProperty(filterOn, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
                 if (propertyInfo != null)
@@ -54,9 +52,21 @@ namespace Library.Dal.Repos.Base
                     // Apply the predicate to filter the query
                     table = table.Where(predicate);
                 }
+
+                // Else check if the filter on follow the <string.strning> pattern
+                else if (filterOn.Contains("."))
+                {
+                    // This time, build the predicate dynamically using System.Linq.Dynamic.Core Package
+                    string constructedLambdaString = LinqHelpers.BuildWherePredicateForNestedProperty<T>(filterOn, filterQuery);
+
+                    // Apply the predicate to filter the query
+                    table = table.Where($"{constructedLambdaString}");
+
+                }
                 else
                 {
-                    throw new ArgumentException("Invalid filterOn property name");
+
+                    throw new ArgumentException("Invalid filterOn property");
                 }
             }
 
@@ -64,7 +74,7 @@ namespace Library.Dal.Repos.Base
             // Sorting
             if (!String.IsNullOrWhiteSpace(sortBy))
             {
-                var propertyInfo = typeof(T).GetProperty(sortBy, BindingFlags.IgnoreCase | BindingFlags.Public |BindingFlags.Instance);
+                var propertyInfo = typeof(T).GetProperty(sortBy, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
 
                 if (propertyInfo != null)
                 {
@@ -84,6 +94,8 @@ namespace Library.Dal.Repos.Base
 
             return table.ToList();
         }
+
+       
 
         protected virtual void Dispose(bool disposing)
         {

--- a/Backend/Library/Library.Dal/Repos/BorrowingRepo.cs
+++ b/Backend/Library/Library.Dal/Repos/BorrowingRepo.cs
@@ -27,7 +27,7 @@
                     .Include(b => b.ReturnedByNavigation)
                     .ToList();
 
-            return Table;
+            return table;
         }
 
         public override async Task<Borrowing> FindAsync(int id)


### PR DESCRIPTION
- Added support for filtering records based on a numeric property using the following rules for the search expression:
Numeric Filtering Criteria:
  1. Exact Value:
      Use the following format to fetch records with an exact numeric value: =42
  2. Greater Than or Equal To:
      Use the following format to fetch records where the numeric property is greater than or equal to a specified value: >=100
  3. Less Than or Equal To:
      Use the following format to fetch records where the numeric property is less than or equal to a specified value: <=50
  4. Greater Than:
      Use the following format to fetch records where the numeric property is strictly greater than a specified value: >200
  5. Less Than:
      Use the following format to fetch records where the numeric property is strictly less than a specified value: <30
  6. Range Between Two Values:
      Use the following format to fetch records where the numeric property falls within a specified range: 10~20


- Added support for filtering based on string/numeric property of a nested property.
  NOTE: the same rules above, for the numeric expression, still works when filtering based on a numeric property of a nested property
  
  @musabsamani  @Mr-Som3a 
