### PR TITLE
Feature/prevent normal user from seeing other user borrowings

### DIFF
--- a/Backend/Library/Library.Api/Controllers/Base/BaseCrudController.cs
+++ b/Backend/Library/Library.Api/Controllers/Base/BaseCrudController.cs
@@ -49,7 +49,7 @@ namespace Library.Api.Controllers.Base
         //[ApiVersion("0.1-Beta")]
         [HttpGet]
         //[Authorize (Roles = "Admin")]
-        public virtual ActionResult<IEnumerable<TResponseDto>> GetAll(
+        public async virtual Task<ActionResult<IEnumerable<TResponseDto>>> GetAll(
             [FromQuery] string? filterOn, [FromQuery] string? filterQuery, // Filtering
             [FromQuery] string? sortBy, [FromQuery] bool? isAscending,    // Sorting
             [FromQuery] int pageSize = 10, [FromQuery] int pageNumber = 1 // Pagination

--- a/Backend/Library/Library.Api/Library.Api.xml
+++ b/Backend/Library/Library.Api/Library.Api.xml
@@ -61,6 +61,12 @@
             <param name="entity">Entity to update</param>
             <returns>Updated record</returns>
         </member>
+        <member name="M:Library.Api.Controllers.BorrowingController.GetAll(System.String,System.String,System.String,System.Nullable{System.Boolean},System.Int32,System.Int32)">
+            <summary>
+            Gets all records
+            </summary>
+            <returns>All records</returns>
+        </member>
         <member name="M:Library.Api.Controllers.BorrowingController.InitiateBorrowingAsync(Library.Models.DTO.PendingBorrowingRequestDTO)">
             <summary>
             Initiate a borrowing request for one or more books

--- a/Backend/Library/Library.Services/DataServices/Dal/Base/BaseDalDataService.cs
+++ b/Backend/Library/Library.Services/DataServices/Dal/Base/BaseDalDataService.cs
@@ -16,8 +16,13 @@ namespace Library.Services.DataServices.Dal.Base
         }
 
 
-        public virtual async Task<IEnumerable<TEntity>> GetAllAsync()
-            => _mainRepo.GetAllIgnoreQueryFilters();
+        public virtual async Task<IEnumerable<TEntity>> GetAllAsync(
+            string? filterOn, string? filterQuery,
+            string? sortBy, bool isAscending,
+            int pageSize, int pageNumber)
+            => _mainRepo.GetAllIgnoreQueryFilters(filterOn, filterQuery,
+                    sortBy, isAscending,
+                    pageSize, pageNumber);
 
         public virtual async Task<TEntity> FindAsync(int id) => await _mainRepo.FindAsync(id);
 

--- a/Backend/Library/Library.Services/DataServices/Interfaces/IBaseDataService.cs
+++ b/Backend/Library/Library.Services/DataServices/Interfaces/IBaseDataService.cs
@@ -5,7 +5,10 @@ namespace Library.Services.DataServices.Interfaces
 {
     public interface IBaseDataService<TEntity> where TEntity : BaseEntity, new()
     {
-        Task<IEnumerable<TEntity>> GetAllAsync();
+        Task<IEnumerable<TEntity>> GetAllAsync(
+            string? filterOn, string? filterQuery,
+            string? sortBy, bool isAscending,
+            int pageSize, int pageNumber);
         Task<TEntity> FindAsync(int id);
         Task<TEntity> UpdateAsync(TEntity entity, bool persist = true);
         Task DeleteAsync(TEntity entity, bool persist = true);


### PR DESCRIPTION
- Restricted the borrowings GetAll endpoint to prevent the normal users from seeing other user's borrowings.
  NOTE: admins can still use the same endpoint to see all borrowings.