### PR TITLE
Feature/add swagger auth

### DIFF
--- a/Backend/Library/Library.Api/Swagger/SwaggerConfiguration.cs
+++ b/Backend/Library/Library.Api/Swagger/SwaggerConfiguration.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 namespace Library.Api.Swagger;
 
@@ -10,20 +11,46 @@ public static class SwaggerConfiguration
         bool addBearerSecurity)
     {
         services.Configure<SwaggerApplicationSettings>(config.GetSection(nameof(SwaggerApplicationSettings)));
-
-        services.AddSwaggerGen(
-            c =>
+        services.AddSwaggerGen(c =>
+        {
+            c.EnableAnnotations();
+            c.IncludeXmlComments(xmlPathAndFile);
+            if (!addBearerSecurity)
             {
-                c.EnableAnnotations();
-                
-                c.IncludeXmlComments(xmlPathAndFile);
-
-                if(!addBearerSecurity)
-                {
-                    return;
-                }
-                // add the authuntication and authorization code here
+                return;
+            }
+            // Enabling authorization using JWT bearer token in the Swagger UI
+            c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+            {
+                Description = "JWT Authorization header using the Bearer scheme. \r\n\r\n" +
+                      "Enter 'Bearer' [space] and then your token in the text input below." +
+                      "\r\n\r\nExample: 'Bearer 12345abcdef'",
+                Name = "Authorization",
+                In = ParameterLocation.Header,
+                Type = SecuritySchemeType.ApiKey,
+                Scheme = JwtBearerDefaults.AuthenticationScheme
             });
+
+            c.AddSecurityRequirement(new OpenApiSecurityRequirement()
+            {
+            {
+                new OpenApiSecurityScheme
+                {
+                    Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = JwtBearerDefaults.AuthenticationScheme
+                        },
+                        Scheme = "Oauth2",
+                        Name = JwtBearerDefaults.AuthenticationScheme,
+                        In = ParameterLocation.Header,
+                },
+                new List<string>()
+                }
+            });
+        });
+
+
 
     }
 }


### PR DESCRIPTION
- Authorize using Swagger UI:
  - Now you can login/register then take your token, press the authorize button and paste your token like in => "Bearer <token>". This will make sure to include the authorization header on each request you make using the Swagger UI.

No need for Postman anymore 😉
@musabsamani  @Mr-Som3a 