### PR TITLE
Feature/add book genre

### DIFF
--- a/Backend/Library/Library.Dal/EFStructures/Migrations/20240517051007_AddGenreToBooks.Designer.cs
+++ b/Backend/Library/Library.Dal/EFStructures/Migrations/20240517051007_AddGenreToBooks.Designer.cs
@@ -4,6 +4,7 @@ using Library.Dal.EFStructures;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Library.Dal.EFStructures.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240517051007_AddGenreToBooks")]
+    partial class AddGenreToBooks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/Library/Library.Dal/EFStructures/Migrations/20240517051007_AddGenreToBooks.cs
+++ b/Backend/Library/Library.Dal/EFStructures/Migrations/20240517051007_AddGenreToBooks.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Library.Dal.EFStructures.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGenreToBooks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "Genre",
+                schema: "libr",
+                table: "Books",
+                type: "bigint",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Genre",
+                schema: "libr",
+                table: "Books");
+        }
+    }
+}

--- a/Backend/Library/Library.Dal/Initialization/SampleData.cs
+++ b/Backend/Library/Library.Dal/Initialization/SampleData.cs
@@ -6,11 +6,71 @@ namespace Library.Dal.Initialization
     {
         public static List<Book> Books => new()
         {
-            new() { Id = 1, Title = "The Old Man and the Sea", Description = "A novel by Ernest Hemingway. It tells the story of an aging Cuban fisherman who struggles with a giant marlin far out in the Gulf Stream.",Credit = 50, ImageURL = "https://m.media-amazon.com/images/I/71RXc0OoEwL._AC_UF894,1000_QL80_.jpg", ImagePath = "https://m.media-amazon.com/images/I/71RXc0OoEwL._AC_UF894,1000_QL80_.jpg", NumberOfTotalCopies = 25, NumberOfAvailableCopies = 24, CreatedAt = new DateTime(2024, 1, 1) },
-            new() { Id = 2, Title = "1984", Description = "A dystopian social science fiction novel by George Orwell. It follows the life of Winston Smith, a low-ranking member of the ruling Party in a totalitarian superstate.",Credit = 80, ImageURL = "https://book-website.com/wp-content/uploads/2023/10/nineteen-eighty-four-1984-george.jpg", ImagePath= "https://book-website.com/wp-content/uploads/2023/10/nineteen-eighty-four-1984-george.jpg" , NumberOfTotalCopies = 18, NumberOfAvailableCopies = 17, CreatedAt = new DateTime(2024,2,1) },
-            new() { Id = 3, Title = "The 7 Habits of Highly Effective People", Description = "A self-help book by Stephen R. Covey. It provides a holistic approach to personal and interpersonal effectiveness.",Credit = 30, ImageURL = "https://m.media-amazon.com/images/I/71y1NKGcGKL._AC_UF894,1000_QL80_DpWeblab_.jpg", ImagePath= "https://m.media-amazon.com/images/I/71y1NKGcGKL._AC_UF894,1000_QL80_DpWeblab_.jpg" , NumberOfTotalCopies = 12, NumberOfAvailableCopies = 10, CreatedAt = new DateTime(2024, 3, 1) },
-            new() { Id = 4, Title = "How to Win Friends & Influence People", Description = "A self-help book by Dale Carnegie. It offers practical advice on how to successfully navigate social and business interactions.",Credit = 20, ImageURL = "https://m.media-amazon.com/images/I/71vK0WVQ4rL._AC_UF894,1000_QL80_.jpg", ImagePath= "https://m.media-amazon.com/images/I/71vK0WVQ4rL._AC_UF894,1000_QL80_.jpg" , NumberOfTotalCopies = 20, NumberOfAvailableCopies = 20, CreatedAt = new DateTime(2024, 4, 1) },
-            new() { Id = 5, Title = "Atomic Habits", Description = "A self-help book by James Clear. It provides practical strategies for building good habits, breaking bad ones, and mastering the tiny behaviors that lead to remarkable results.",Credit = 5, ImageURL = "https://m.media-amazon.com/images/I/81YkqyaFVEL._AC_UF1000,1000_QL80_.jpg", ImagePath = "https://m.media-amazon.com/images/I/81YkqyaFVEL._AC_UF1000,1000_QL80_.jpg", NumberOfTotalCopies = 15, NumberOfAvailableCopies = 15, CreatedAt = new DateTime(2024, 8, 1) },
+            new()
+            {
+                Id = 1,
+                Title = "The Old Man and the Sea",
+                Description = "A novel by Ernest Hemingway. It tells the story of an aging Cuban fisherman who struggles with a giant marlin far out in the Gulf Stream.",
+                BookGenre = Genre.Fiction,
+                Credit = 50,
+                ImageURL = "https://m.media-amazon.com/images/I/71RXc0OoEwL._AC_UF894,1000_QL80_.jpg",
+                ImagePath = "https://m.media-amazon.com/images/I/71RXc0OoEwL._AC_UF894,1000_QL80_.jpg",
+                NumberOfTotalCopies = 25,
+                NumberOfAvailableCopies = 24,
+                CreatedAt = new DateTime(2024, 1, 1)
+            },
+            new()
+            {
+                Id = 2,
+                Title = "1984",
+                Description = "A dystopian social science fiction novel by George Orwell. It follows the life of Winston Smith, a low-ranking member of the ruling Party in a totalitarian superstate.",
+                BookGenre = Genre.Fiction | Genre.ScienceFiction,
+                Credit = 80,
+                ImageURL = "https://book-website.com/wp-content/uploads/2023/10/nineteen-eighty-four-1984-george.jpg",
+                ImagePath= "https://book-website.com/wp-content/uploads/2023/10/nineteen-eighty-four-1984-george.jpg",
+                NumberOfTotalCopies = 18,
+                NumberOfAvailableCopies = 17,
+                CreatedAt = new DateTime(2024,2,1)
+            },
+            new()
+            {
+                Id = 3,
+                Title = "The 7 Habits of Highly Effective People",
+                Description = "A self-help book by Stephen R. Covey. It provides a holistic approach to personal and interpersonal effectiveness.",
+                BookGenre = Genre.SelfHelp,
+                Credit = 30,
+                ImageURL = "https://m.media-amazon.com/images/I/71y1NKGcGKL._AC_UF894,1000_QL80_DpWeblab_.jpg",
+                ImagePath= "https://m.media-amazon.com/images/I/71y1NKGcGKL._AC_UF894,1000_QL80_DpWeblab_.jpg",
+                NumberOfTotalCopies = 12,
+                NumberOfAvailableCopies = 10,
+                CreatedAt = new DateTime(2024, 3, 1)
+            },
+            new()
+            {
+                Id = 4,
+                Title = "How to Win Friends & Influence People",
+                Description = "A self-help book by Dale Carnegie. It offers practical advice on how to successfully navigate social and business interactions.",
+                BookGenre = Genre.SelfHelp,
+                Credit = 20,
+                ImageURL = "https://m.media-amazon.com/images/I/71vK0WVQ4rL._AC_UF894,1000_QL80_.jpg",
+                ImagePath= "https://m.media-amazon.com/images/I/71vK0WVQ4rL._AC_UF894,1000_QL80_.jpg",
+                NumberOfTotalCopies = 20,
+                NumberOfAvailableCopies = 20,
+                CreatedAt = new DateTime(2024, 4, 1)
+            },
+            new()
+            {
+                Id = 5,
+                Title = "Atomic Habits",
+                Description = "A self-help book by James Clear. It provides practical strategies for building good habits, breaking bad ones, and mastering the tiny behaviors that lead to remarkable results.",
+                BookGenre = Genre.SelfHelp,
+                Credit = 5,
+                ImageURL = "https://m.media-amazon.com/images/I/81YkqyaFVEL._AC_UF1000,1000_QL80_.jpg",
+                ImagePath = "https://m.media-amazon.com/images/I/81YkqyaFVEL._AC_UF1000,1000_QL80_.jpg",
+                NumberOfTotalCopies = 15,
+                NumberOfAvailableCopies = 15,
+                CreatedAt = new DateTime(2024, 8, 1)
+            },
         };
 
         public static List<Author> Authors => new()

--- a/Backend/Library/Library.Models/DTO/Book/BookCreateRequestDTO.cs
+++ b/Backend/Library/Library.Models/DTO/Book/BookCreateRequestDTO.cs
@@ -13,6 +13,9 @@ namespace Library.Models.DTO
 
         public string? Description { get; set; }
 
+        public Genre? BookGenre { get; set; }
+
+
         public int Credit { get; set; }
 
         public IFormFile? Image { get; set; }

--- a/Backend/Library/Library.Models/DTO/Book/BookDTO.cs
+++ b/Backend/Library/Library.Models/DTO/Book/BookDTO.cs
@@ -11,6 +11,9 @@ namespace Library.Models.DTO
 
         public string? Description { get; set; }
 
+        public Genre? BookGenre { get; set; }
+
+
         public int Credit { get; set; }
 
 

--- a/Backend/Library/Library.Models/DTO/Book/BookResponseDTO.cs
+++ b/Backend/Library/Library.Models/DTO/Book/BookResponseDTO.cs
@@ -11,6 +11,8 @@ namespace Library.Models.DTO
 
         public string? Description { get; set; }
 
+        public Genre? BookGenre { get; set; }
+
         public int Credit { get; set; }
 
         public string? ImageURL { get; set; }

--- a/Backend/Library/Library.Models/DTO/Book/BookUpdateRequestDTO.cs
+++ b/Backend/Library/Library.Models/DTO/Book/BookUpdateRequestDTO.cs
@@ -12,6 +12,9 @@ namespace Library.Models.DTO
 
         public string? Description { get; set; }
 
+        public Genre? BookGenre { get; set; }
+
+
         public int Credit { get; set; }
 
         public List<int>? AuthorsIds { get; set; }

--- a/Backend/Library/Library.Models/Entities/Book.cs
+++ b/Backend/Library/Library.Models/Entities/Book.cs
@@ -13,6 +13,9 @@ namespace Library.Models.Entities
 
         public string? Description { get; set; }
 
+        [Column("Genre")]
+        public Genre? BookGenre { get; set; }
+
         public int Credit { get; set; }
 
         public string? ImageURL { get; set; }
@@ -52,4 +55,48 @@ namespace Library.Models.Entities
 
         public DateTime CreatedAt { get; set; }
     }
+
+    [Flags]
+    public enum Genre : long
+    {
+        None = 0L,
+        SelfHelp = 1L << 0,        // 1
+        Fiction = 1L << 1,         // 2
+        Education = 1L << 2,       // 4
+        Business = 1L << 3,        // 8
+        Technology = 1L << 4,      // 16
+        Medicine = 1L << 5,        // 32
+        History = 1L << 6,         // 64
+        Politics = 1L << 7,        // 128
+        Arts = 1L << 8,            // 256
+        Law = 1L << 9,             // 512
+        Science = 1L << 10,        // 1024
+        Psychology = 1L << 11,     // 2048
+        Religion = 1L << 12,       // 4096
+        Travel = 1L << 13,         // 8192
+        Music = 1L << 14,          // 16384
+        Film = 1L << 15,           // 32768
+        Drama = 1L << 16,          // 65536
+        Comedy = 1L << 17,         // 131072
+        Animation = 1L << 18,      // 262144
+        Game = 1L << 19,           // 524288
+        Anime = 1L << 20,          // 1048576
+        Cartoon = 1L << 21,        // 2097152
+        Children = 1L << 22,       // 4194304
+        Comics = 1L << 23,         // 8388608
+        Fantasy = 1L << 24,        // 16777216
+        Horror = 1L << 25,         // 33554432
+        ScienceFiction = 1L << 26, // 67108864
+        Romance = 1L << 27,        // 134217728
+        Thriller = 1L << 28,       // 268435456
+        Mystery = 1L << 29,        // 536870912
+        Historical = 1L << 30,     // 1073741824
+        Biography = 1L << 31,      // 2147483648
+        Poetry = 1L << 32,         // 4294967296
+        Cooking = 1L << 33,        // 8589934592
+        Health = 1L << 34,         // 17179869184
+        Art = 1L << 35,            // 34359738368
+        Other = 1L << 36           // 68719476736
+    }
+
 }


### PR DESCRIPTION
- Add Genre to the Book table.
- Updated the sample data to include Genres.
- Updated the DTOs.

- Things to watch out for:
1. Use the Genre Enum you find in the Swagger Schemas (The section below the endpoints) to identify the available Genres.
2. We can have more than one genre for a book, but when adding a new book only one genre can be specified, this is a limitation that I might resolve later, but for now if you want to provide more than one genre you need to hit the update book endpoint and use the following syntax for the book genre:
"Genre1, Genre2, Genre3 ... etc."

@musabsamani  @Mr-Som3a 